### PR TITLE
Fix cropping image in the main thread

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Thanks to [@yefimtsev](https://github.com/yefimtsev) for adding the ability to c
 
 Thanks to [@SuperY](https://github.com/SuperY) for adding the chinese localization 🇨🇳
 
+Thanks to [@mosliem](https://github.com/mosliem) for adding the cropping in background thread 🧵
+
 ## ✍️ Author
 
 Benedikt Betz

--- a/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
+++ b/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
@@ -18,16 +18,19 @@ public struct SwiftyCropConfiguration {
             // We cannot use the localized values here because module access is not given in init
             cancelButton: String? = nil,
             interactionInstructions: String? = nil,
-            saveButton: String? = nil
+            saveButton: String? = nil,
+            progressLayerText: String? = nil
         ) {
             self.cancelButton = cancelButton
             self.interactionInstructions = interactionInstructions
             self.saveButton = saveButton
+            self.progressLayerText = progressLayerText
         }
         
         public let cancelButton: String?
         public let interactionInstructions: String?
         public let saveButton: String?
+        public let progressLayerText: String?
     }
 
     public struct Fonts {

--- a/Sources/SwiftyCrop/Resources/Localizable.xcstrings
+++ b/Sources/SwiftyCrop/Resources/Localizable.xcstrings
@@ -167,6 +167,17 @@
         }
       }
     },
+    "processing_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing"
+          }
+        }
+      }
+    },
     "save_button" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/SwiftyCrop/Resources/Localizable.xcstrings
+++ b/Sources/SwiftyCrop/Resources/Localizable.xcstrings
@@ -170,12 +170,19 @@
     "processing_label" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing"
-          }
-        }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Processing" } },
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Verarbeitung" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Procesando" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Traitement" } },
+        "hu" : { "stringUnit" : { "state" : "translated", "value" : "Feldolgozás" } },
+        "it" : { "stringUnit" : { "state" : "translated", "value" : "Elaborazione" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "処理中" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "처리 중" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Processando" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Обработка" } },
+        "tr" : { "stringUnit" : { "state" : "translated", "value" : "İşleniyor" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "Обробка" } },
+        "zh" : { "stringUnit" : { "state" : "translated", "value" : "处理中" } }
       }
     },
     "save_button" : {

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct CropView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: CropViewModel
+    
+    @State private var isCropping: Bool = false
 
     private let image: UIImage
     private let maskShape: MaskShape
@@ -31,8 +33,37 @@ struct CropView: View {
         localizableTableName = "Localizable"
     }
 
+    // MARK: - Body
     var body: some View {
-        let magnificationGesture = MagnificationGesture()
+        ZStack {
+            VStack {
+                instructionText
+                cropImageView
+                cropToolbar
+            }
+            .background(configuration.colors.background)
+            .onChange(of: isCropping) { value in
+                if value {
+                    DispatchQueue.global(qos: .background).async { // do cropping process in the background
+                        let result = cropImage()
+                        
+                        DispatchQueue.main.async {
+                            onComplete(result)
+                            dismiss()
+                        }
+                    }
+                }
+            }
+            
+            if isCropping {
+                progressLayer
+            }
+        }
+    }
+
+    // MARK: - Gestures
+    private var magnificationGesture: some Gesture {
+        MagnificationGesture()
             .onChanged { value in
                 let sensitivity: CGFloat = 0.1 * configuration.zoomSensitivity
                 let scaledValue = (value.magnitude - 1) * sensitivity + 1
@@ -46,8 +77,10 @@ struct CropView: View {
                 viewModel.lastScale = viewModel.scale
                 viewModel.lastOffset = viewModel.offset
             }
+    }
 
-        let dragGesture = DragGesture()
+    private var dragGesture: some Gesture {
+        DragGesture()
             .onChanged { value in
                 let maxOffsetPoint = viewModel.calculateDragGestureMax()
                 let newX = min(
@@ -63,102 +96,138 @@ struct CropView: View {
             .onEnded { _ in
                 viewModel.lastOffset = viewModel.offset
             }
+    }
 
-        let rotationGesture = RotationGesture()
+    private var rotationGesture: some Gesture {
+        RotationGesture()
             .onChanged { value in
                 viewModel.angle = viewModel.lastAngle + value
             }
             .onEnded { _ in
                 viewModel.lastAngle = viewModel.angle
             }
-
-        VStack {
-            Text(
-                configuration.texts.interactionInstructions ??
-                NSLocalizedString("interaction_instructions", tableName: localizableTableName, bundle: .module, comment: "")
-            )
-            .font(configuration.fonts.interactionInstructions)
-            .foregroundColor(configuration.colors.interactionInstructions)
-            .padding(.top, 30)
-            .zIndex(1)
-
-            ZStack {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .rotationEffect(viewModel.angle)
-                    .scaleEffect(viewModel.scale)
-                    .offset(viewModel.offset)
-                    .opacity(0.5)
-                    .overlay(
-                        GeometryReader { geometry in
-                            Color.clear
-                                .onAppear {
-                                    viewModel.updateMaskDimensions(for: geometry.size)
-                                }
-                        }
-                    )
-
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .rotationEffect(viewModel.angle)
-                    .scaleEffect(viewModel.scale)
-                    .offset(viewModel.offset)
-                    .mask(
-                        MaskShapeView(maskShape: maskShape)
-                            .frame(width: viewModel.maskSize.width, height: viewModel.maskSize.height)
-                    )
-                
-                VStack {
-                    Spacer()
-                    HStack {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Text(
-                                configuration.texts.cancelButton ??
-                                NSLocalizedString("cancel_button", tableName: localizableTableName, bundle: .module, comment: "")
-                            )
-                            .padding()
-                            .font(configuration.fonts.cancelButton)
-                            .foregroundColor(configuration.colors.cancelButton)
-                        }
-                        .padding()
-                        
-                        Spacer()
-
-                        Button {
-                            onComplete(cropImage())
-                            dismiss()
-                        } label: {
-                            Text(
-                                configuration.texts.saveButton ??
-                                NSLocalizedString("save_button", tableName: localizableTableName, bundle: .module, comment: "")
-                            )
-                            .padding()
-                            .font(configuration.fonts.saveButton)
-                            .foregroundColor(configuration.colors.saveButton)
-                        }
-                        .padding()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .bottom)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .simultaneousGesture(magnificationGesture)
-            .simultaneousGesture(dragGesture)
-            .simultaneousGesture(configuration.rotateImage ? rotationGesture : nil)
-        }
-        .background(configuration.colors.background)
     }
 
+    // MARK: - UI Components
+    private var instructionText: some View {
+        Text(
+            configuration.texts.interactionInstructions ??
+            NSLocalizedString("interaction_instructions", tableName: localizableTableName, bundle: .module, comment: "")
+        )
+        .font(configuration.fonts.interactionInstructions)
+        .foregroundColor(configuration.colors.interactionInstructions)
+        .padding(.top, 30)
+        .zIndex(1)
+    }
+
+    private var cropImageView: some View {
+        ZStack {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .rotationEffect(viewModel.angle)
+                .scaleEffect(viewModel.scale)
+                .offset(viewModel.offset)
+                .opacity(0.5)
+                .overlay(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .onAppear {
+                                viewModel.updateMaskDimensions(for: geometry.size)
+                            }
+                    }
+                )
+
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .rotationEffect(viewModel.angle)
+                .scaleEffect(viewModel.scale)
+                .offset(viewModel.offset)
+                .mask(
+                    MaskShapeView(maskShape: maskShape)
+                        .frame(width: viewModel.maskSize.width, height: viewModel.maskSize.height)
+                )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .simultaneousGesture(magnificationGesture)
+        .simultaneousGesture(dragGesture)
+        .simultaneousGesture(configuration.rotateImage ? rotationGesture : nil)
+    }
+
+    private var cropToolbar: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Text(
+                        configuration.texts.cancelButton ??
+                        NSLocalizedString("cancel_button", tableName: localizableTableName, bundle: .module, comment: "")
+                    )
+                    .padding()
+                    .font(configuration.fonts.cancelButton)
+                    .foregroundColor(configuration.colors.cancelButton)
+                }
+                .padding()
+                
+                Spacer()
+
+                Button {
+                    isCropping = true
+                } label: {
+                    Text(
+                        configuration.texts.saveButton ??
+                        NSLocalizedString("save_button", tableName: localizableTableName, bundle: .module, comment: "")
+                    )
+                    .padding()
+                    .font(configuration.fonts.saveButton)
+                    .foregroundColor(configuration.colors.saveButton)
+                }
+                .padding()
+            }
+            .frame(maxWidth: .infinity, alignment: .bottom)
+        }
+    }
+
+    // MARK: - Helpers
     private func updateOffset() {
         let maxOffsetPoint = viewModel.calculateDragGestureMax()
         let newX = min(max(viewModel.offset.width, -maxOffsetPoint.x), maxOffsetPoint.x)
         let newY = min(max(viewModel.offset.height, -maxOffsetPoint.y), maxOffsetPoint.y)
         viewModel.offset = CGSize(width: newX, height: newY)
         viewModel.lastOffset = viewModel.offset
+    }
+
+    private var progressLayer: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+            
+            VStack(alignment: .center, spacing: 5) {
+                
+                Spacer(minLength: 35)
+                
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .scaleEffect(1.2)
+                
+                Spacer()
+                
+                Text(NSLocalizedString("processing_label", tableName: localizableTableName, bundle: .module, comment: ""))
+                    .font(.body)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 12)
+                
+            }
+            .frame(width: 120, height: 110)
+            .background(Color.gray)
+            .cornerRadius(12)
+            .padding(.vertical, 5)
+            .padding(.horizontal, 15)
+        }
+        .transition(.opacity)
     }
 
     private func cropImage() -> UIImage? {
@@ -180,6 +249,7 @@ struct CropView: View {
         }
     }
 
+    // MARK: - Mask Shape View
     private struct MaskShapeView: View {
         let maskShape: MaskShape
 


### PR DESCRIPTION
This PR fixes performing the cropping process in the main thread, which leads to UI lag if the image size is large.

1. Handle using the appropriate thread for each action [Cropping - UI updates].
2. Add a progress view when cropping is in progress.
3. Enhance the code base structure in `CropView`.