### PR TITLE
Add onCancel completion callback

### DIFF
--- a/Demo/SwiftyCropDemo/ContentView.swift
+++ b/Demo/SwiftyCropDemo/ContentView.swift
@@ -174,7 +174,10 @@ struct ContentView: View {
             usesLiquidGlassDesign: usesLiquidGlassDesign,
             zoomSensitivity: zoomSensitivity,
             rectAspectRatio: rectAspectRatio.getValue()
-          )
+          ),
+          onCancel: {
+            print("Operation cancelled")
+          }
         ) { croppedImage in
           // Do something with the returned, cropped image
           self.selectedImage = croppedImage

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ struct ExampleView: View {
 If you want to display `SwiftyCrop` inside a sheet, use `NavigationView` instead of `NavigationStack` in case you want to wrap it.
 ```
 
-SwiftyCrop supports two different mask shapes for cropping:
+SwiftyCrop supports three different mask shapes for cropping:
 - `circle`
 - `square`
 - `rectangle`

--- a/Sources/SwiftyCrop/SwiftyCrop.swift
+++ b/Sources/SwiftyCrop/SwiftyCrop.swift
@@ -8,23 +8,27 @@ import SwiftUI
 ///   - imageToCrop: The image to be cropped.
 ///   - maskShape: The shape of the mask used for cropping.
 ///   - configuration: The configuration for the cropping behavior. If nothing is specified, the default is used.
+///   - onCancel: An optional closure that's called when the cropping is cancelled.
 ///   - onComplete: A closure that's called when the cropping is complete. This closure returns the cropped `UIImage?`.
 ///     If an error occurs the return value is nil.
 public struct SwiftyCropView: View {
     private let imageToCrop: UIImage
     private let maskShape: MaskShape
     private let configuration: SwiftyCropConfiguration
+    private let onCancel: (() -> Void)?
     private let onComplete: (UIImage?) -> Void
 
     public init(
         imageToCrop: UIImage,
         maskShape: MaskShape,
         configuration: SwiftyCropConfiguration = SwiftyCropConfiguration(),
+        onCancel: (() -> Void)? = nil,
         onComplete: @escaping (UIImage?) -> Void
     ) {
         self.imageToCrop = imageToCrop
         self.maskShape = maskShape
         self.configuration = configuration
+        self.onCancel = onCancel
         self.onComplete = onComplete
     }
 
@@ -33,6 +37,7 @@ public struct SwiftyCropView: View {
             image: imageToCrop,
             maskShape: maskShape,
             configuration: configuration,
+            onCancel: onCancel,
             onComplete: onComplete
         )
     }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -10,6 +10,7 @@ struct CropView: View {
   private let image: UIImage
   private let maskShape: MaskShape
   private let configuration: SwiftyCropConfiguration
+  private let onCancel: (() -> Void)?
   private let onComplete: (UIImage?) -> Void
   private let localizableTableName: String
   
@@ -17,11 +18,13 @@ struct CropView: View {
     image: UIImage,
     maskShape: MaskShape,
     configuration: SwiftyCropConfiguration,
+    onCancel: (() -> Void)? = nil,
     onComplete: @escaping (UIImage?) -> Void
   ) {
     self.image = image
     self.maskShape = maskShape
     self.configuration = configuration
+    self.onCancel = onCancel
     self.onComplete = onComplete
     _viewModel = StateObject(
       wrappedValue: CropViewModel(
@@ -48,14 +51,17 @@ struct CropView: View {
 #endif
   }
   
-  @available (iOS 26, *)
+  @available(iOS 26, *)
   private func buildLiquidGlassBody(configuration: SwiftyCropConfiguration) -> some View {
     ZStack {
       VStack {
         ToolbarView(
           viewModel: viewModel,
           configuration: configuration,
-          dismiss: { dismiss() }
+          dismiss: {
+            onCancel?()
+            dismiss()
+          }
         ) {
           await MainActor.run {
             isCropping = true
@@ -105,7 +111,10 @@ struct CropView: View {
         Legacy_ButtonsView(
           configuration: configuration,
           localizableTableName: localizableTableName,
-          dismiss: { dismiss() }
+          dismiss: {
+            onCancel?()
+            dismiss()
+          }
         ) {
           await MainActor.run {
             isCropping = true


### PR DESCRIPTION
## Summary

* Add an `onCancel` completion for `SwiftyCropView`, since sometimes users need to be aware that the operation is cancelled. It's in parallel to the existing `onCompletion`.