### PR TITLE
Add support for visionOS

### DIFF
--- a/Demo/SwiftyCropDemo/ContentView.swift
+++ b/Demo/SwiftyCropDemo/ContentView.swift
@@ -123,14 +123,16 @@ struct ContentView: View {
           HStack {
             Text("Mask radius")
               .frame(maxWidth: .infinity, alignment: .leading)
-            
+
+#if os(iOS)
             Button {
               maskRadius = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height) / 2
             } label: {
               Image(systemName: "arrow.up.left.and.arrow.down.right")
                 .font(.footnote)
             }
-            
+#endif
+
             DecimalTextField(value: $maskRadius)
               .focused($textFieldFocused)
           }
@@ -146,6 +148,13 @@ struct ContentView: View {
         }
       }
       .toolbar {
+#if os(visionOS)
+        ToolbarItemGroup(placement: .bottomOrnament) {
+          Button("Done") {
+            textFieldFocused = false
+          }
+        }
+#else
         ToolbarItemGroup(placement: .keyboard) {
           Spacer()
           
@@ -153,6 +162,7 @@ struct ContentView: View {
             textFieldFocused = false
           }
         }
+#endif
       }
       .buttonStyle(.bordered)
       .padding()

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,10 @@ import PackageDescription
 let package = Package(
     name: "SwiftyCrop",
     defaultLocalization: "en",
-    platforms: [.iOS(.v16)],
+    platforms: [
+      .iOS(.v16),
+      .visionOS(.v1)
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Thanks to [@SuperY](https://github.com/SuperY) for adding the chinese localizati
 
 Thanks to [@mosliem](https://github.com/mosliem) for adding the cropping in background thread 🧵
 
+Thanks to [@krayc425](https://github.com/krayc425) for adding visionOS support 🕶️
+
 ## 📃 License
 
 `SwiftyCrop` is available under the MIT license. See the [LICENSE](https://github.com/benedom/SwiftyCrop/blob/master/LICENSE.md) file for more info.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Build](https://github.com/benedom/SwiftyCrop/actions/workflows/build-swift.yml/badge.svg?branch=master)](https://github.com/benedom/SwiftyCrop/actions/workflows/build-swift.yml)
 ![Static Badge](https://img.shields.io/badge/Platform%20-%20iOS%20-%20light_green)
 ![Static Badge](https://img.shields.io/badge/iOS%20-%20%3E%2016.0%20-%20light_green)
+![Static Badge](https://img.shields.io/badge/Platform%20-%20visionOS%20-%20light_green)
+![Static Badge](https://img.shields.io/badge/visionOS%20-%20%3E%201.0%20-%20light_green)
 ![Static Badge](https://img.shields.io/badge/Swift%20-%20%3E%205.9%20-%20orange)
 <a href="LICENSE.md">
   <img src="https://img.shields.io/badge/License%20-%20MIT%20-%20blue" alt="License - MIT">

--- a/Sources/SwiftyCrop/View/Components/LiquidGlass/ProgressLayer.swift
+++ b/Sources/SwiftyCrop/View/Components/LiquidGlass/ProgressLayer.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@available(iOS 26, *)
+@available(iOS 26, visionOS 26.0, *)
 struct ProgressLayer: View {
   let configuration: SwiftyCropConfiguration
   let localizableTableName: String
@@ -25,10 +25,12 @@ struct ProgressLayer: View {
         .foregroundColor(configuration.colors.interactionInstructions)
       }
       .padding(25)
+#if !os(visionOS)
       .glassEffect(
         .regular.tint(configuration.colors.background.opacity(0.8)),
         in: .rect(cornerRadius: 12)
       )
+#endif
       .padding(.vertical, 5)
       .padding(.horizontal, 20)
     }
@@ -42,7 +44,7 @@ struct ProgressLayer: View {
   }
 }
 
-@available(iOS 26, *)
+@available(iOS 26, visionOS 26.0, *)
 #Preview {
   ProgressLayer(configuration: .init(), localizableTableName: "Localizable")
 }

--- a/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
+++ b/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@available(iOS 26, *)
+@available(iOS 26, visionOS 26.0, *)
 struct ToolbarView: View {
   @ObservedObject var viewModel: CropViewModel
   let configuration: SwiftyCropConfiguration
@@ -19,8 +19,10 @@ struct ToolbarView: View {
           .fontWeight(.semibold)
       }
       .padding()
+#if !os(visionOS)
       .glassEffect()
-      
+#endif
+
       Spacer()
       
       if configuration.rotateImageWithButtons {
@@ -38,7 +40,9 @@ struct ToolbarView: View {
             .fontWeight(.semibold)
         }
         .padding()
+#if !os(visionOS)
         .glassEffect()
+#endif
         .opacity(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0 ? 0.7 : 1)
         .disabled(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0)
         
@@ -67,7 +71,9 @@ struct ToolbarView: View {
           }
           .padding()
         }
+#if !os(visionOS)
         .glassEffect()
+#endif
       }
       
       Spacer()
@@ -85,7 +91,9 @@ struct ToolbarView: View {
       }
       .padding()
       .disabled(isCropping)
+#if !os(visionOS)
       .glassEffect(.regular.tint(Color.yellow))
+#endif
     }
     .frame(maxWidth: .infinity)
 #else

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -41,7 +41,7 @@ struct CropView: View {
   var body: some View {
 #if compiler(>=6.2) // Use this to prevent compiling of unavailable iOS 26 APIs
     if configuration.usesLiquidGlassDesign,
-       #available(iOS 26, *) {
+       #available(iOS 26, visionOS 26.0, *) {
       buildLiquidGlassBody(configuration: configuration)
     } else {
       buildLegacyBody(configuration: configuration)
@@ -51,7 +51,7 @@ struct CropView: View {
 #endif
   }
   
-  @available(iOS 26, *)
+  @available(iOS 26, visionOS 26.0, *)
   private func buildLiquidGlassBody(configuration: SwiftyCropConfiguration) -> some View {
     ZStack {
       VStack {


### PR DESCRIPTION
## Summary

* Add `.visionOS(.v1)` in `Package.swift`.
* Add `#if !os(visionOS)` and `@available(iOS 26, visionOS 26.0, *)` checks for Liquid Glass UI components, since `glassEffect` modifier is not available in visionOS.

<img width="3840" height="2160" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-14 at 02 36 44" src="https://github.com/user-attachments/assets/60d201f1-bef5-452d-9b59-e1f45886f443" />
<img width="3840" height="2160" alt="Simulator Screenshot - Apple Vision Pro - 2025-07-14 at 02 36 48" src="https://github.com/user-attachments/assets/aa4c47d9-e700-4a68-8039-2edbf7544fa5" />