### PR TITLE
Update Liquid Glass Implementation and Fix Legacy Rotate Button

### DIFF
--- a/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
+++ b/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 @available(iOS 26, visionOS 26.0, *)
 struct ToolbarView: View {
-  @ObservedObject var viewModel: CropViewModel
-  let configuration: SwiftyCropConfiguration
-  let dismiss: () -> Void
-  let onComplete: () async -> Void
-  @State private var isCropping = false
-  
+    @ObservedObject var viewModel: CropViewModel
+    let configuration: SwiftyCropConfiguration
+    let dismiss: () -> Void
+    let onComplete: () async -> Void
+    @State private var isCropping = false
+    
     var body: some View {
 #if compiler(>=6.2) // Use this to prevent compiling of unavailable iOS 26 APIs
         GlassEffectContainer {
@@ -98,13 +98,13 @@ struct ToolbarView: View {
 #endif
             }
         }
-            .contentShape(Capsule())
-            .frame(maxWidth: .infinity)
+        .contentShape(Capsule())
+        .frame(maxWidth: .infinity)
 #else
-            VStack {
-                Text("iOS 26 is not supported. Adjust the simulator or your Xcode version.")
-            }
-            .border(.red)
-#endif
+        VStack {
+            Text("iOS 26 is not supported. Adjust the simulator or your Xcode version.")
         }
+        .border(.red)
+#endif
     }
+}

--- a/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
+++ b/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
@@ -22,7 +22,7 @@ struct ToolbarView: View {
                 }
                 .padding()
 #if !os(visionOS)
-                .glassEffect(.regular.tint(configuration.colors.cancelButtonBackground))
+                .glassEffect(.regular.tint(configuration.colors.cancelButtonBackground).interactive())
 #endif
                 
                 Spacer()
@@ -43,7 +43,7 @@ struct ToolbarView: View {
                     }
                     .padding()
 #if !os(visionOS)
-                    .glassEffect(.regular.tint(configuration.colors.resetRotationButtonBackground))
+                    .glassEffect(.regular.tint(configuration.colors.resetRotationButtonBackground).interactive())
 #endif
                     .opacity(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0 ? 0.7 : 1)
                     .disabled(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0)
@@ -74,7 +74,7 @@ struct ToolbarView: View {
                         .padding()
                     }
 #if !os(visionOS)
-                    .glassEffect(.regular.tint(configuration.colors.rotateButtonBackground))
+                    .glassEffect(.regular.tint(configuration.colors.rotateButtonBackground).interactive())
 #endif
                 }
                 
@@ -94,7 +94,7 @@ struct ToolbarView: View {
                 .padding()
                 .disabled(isCropping)
 #if !os(visionOS)
-                .glassEffect(.regular.tint(configuration.colors.saveButtonBackground))
+                .glassEffect(.regular.tint(configuration.colors.saveButtonBackground).interactive())
 #endif
             }
         }

--- a/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
+++ b/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
@@ -98,6 +98,7 @@ struct ToolbarView: View {
 #endif
             }
         }
+            .contentShape(Capsule())
             .frame(maxWidth: .infinity)
 #else
             VStack {

--- a/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
+++ b/Sources/SwiftyCrop/View/Components/LiquidGlass/ToolbarView.swift
@@ -8,100 +8,102 @@ struct ToolbarView: View {
   let onComplete: () async -> Void
   @State private var isCropping = false
   
-  var body: some View {
+    var body: some View {
 #if compiler(>=6.2) // Use this to prevent compiling of unavailable iOS 26 APIs
-    HStack {
-      Button {
-        dismiss()
-      } label: {
-        Image(systemName: "xmark")
-          .foregroundStyle(configuration.colors.cancelButton)
-        
-          .fontWeight(.semibold)
-      }
-      .padding()
+        GlassEffectContainer {
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(configuration.colors.cancelButton)
+                    
+                        .fontWeight(.semibold)
+                }
+                .padding()
 #if !os(visionOS)
-      .glassEffect(.regular.tint(configuration.colors.cancelButtonBackground))
+                .glassEffect(.regular.tint(configuration.colors.cancelButtonBackground))
 #endif
-
-      Spacer()
-      
-      if configuration.rotateImageWithButtons {
-        Button {
-          // The reset button should only reset by the amount needed, prevents rotating the image back multiple times if it was rotated multiple times
-          let numberOfFullCircles = Int(viewModel.angle.degrees / 360)
-          let newValue = Double(numberOfFullCircles * 360)
-          withAnimation {
-            viewModel.angle = Angle(degrees: newValue)
-            viewModel.lastAngle = viewModel.angle
-          }
-        } label: {
-          Image(systemName: "arrow.uturn.backward.circle")
-            .foregroundStyle(configuration.colors.resetRotationButton)
-            .fontWeight(.semibold)
-        }
-        .padding()
+                
+                Spacer()
+                
+                if configuration.rotateImageWithButtons {
+                    Button {
+                        // The reset button should only reset by the amount needed, prevents rotating the image back multiple times if it was rotated multiple times
+                        let numberOfFullCircles = Int(viewModel.angle.degrees / 360)
+                        let newValue = Double(numberOfFullCircles * 360)
+                        withAnimation {
+                            viewModel.angle = Angle(degrees: newValue)
+                            viewModel.lastAngle = viewModel.angle
+                        }
+                    } label: {
+                        Image(systemName: "arrow.uturn.backward.circle")
+                            .foregroundStyle(configuration.colors.resetRotationButton)
+                            .fontWeight(.semibold)
+                    }
+                    .padding()
 #if !os(visionOS)
-        .glassEffect(.regular.tint(configuration.colors.resetRotationButtonBackground))
+                    .glassEffect(.regular.tint(configuration.colors.resetRotationButtonBackground))
 #endif
-        .opacity(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0 ? 0.7 : 1)
-        .disabled(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0)
-        
-        HStack {
-          Button {
-            withAnimation {
-              viewModel.angle.degrees -= 90
-              viewModel.lastAngle = viewModel.angle
+                    .opacity(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0 ? 0.7 : 1)
+                    .disabled(viewModel.angle.degrees.truncatingRemainder(dividingBy: 360) == 0)
+                    
+                    HStack {
+                        Button {
+                            withAnimation {
+                                viewModel.angle.degrees -= 90
+                                viewModel.lastAngle = viewModel.angle
+                            }
+                        } label: {
+                            Image(systemName: "rotate.left")
+                                .foregroundStyle(configuration.colors.rotateButton)
+                                .fontWeight(.semibold)
+                        }
+                        .padding()
+                        
+                        Button {
+                            withAnimation {
+                                viewModel.angle.degrees += 90
+                                viewModel.lastAngle = viewModel.angle
+                            }
+                        } label: {
+                            Image(systemName: "rotate.right")
+                                .foregroundStyle(configuration.colors.rotateButton)
+                                .fontWeight(.semibold)
+                        }
+                        .padding()
+                    }
+#if !os(visionOS)
+                    .glassEffect(.regular.tint(configuration.colors.rotateButtonBackground))
+#endif
+                }
+                
+                Spacer()
+                
+                Button {
+                    Task {
+                        isCropping = true
+                        defer { isCropping = false }
+                        await onComplete()
+                    }
+                } label: {
+                    Image(systemName: "checkmark")
+                        .fontWeight(.semibold)
+                        .foregroundStyle(configuration.colors.saveButton)
+                }
+                .padding()
+                .disabled(isCropping)
+#if !os(visionOS)
+                .glassEffect(.regular.tint(configuration.colors.saveButtonBackground))
+#endif
             }
-          } label: {
-            Image(systemName: "rotate.left")
-              .foregroundStyle(configuration.colors.rotateButton)
-              .fontWeight(.semibold)
-          }
-          .padding()
-          
-          Button {
-            withAnimation {
-              viewModel.angle.degrees += 90
-              viewModel.lastAngle = viewModel.angle
-            }
-          } label: {
-            Image(systemName: "rotate.right")
-              .foregroundStyle(configuration.colors.rotateButton)
-              .fontWeight(.semibold)
-          }
-          .padding()
         }
-#if !os(visionOS)
-        .glassEffect(.regular.tint(configuration.colors.rotateButtonBackground))
-#endif
-      }
-      
-      Spacer()
-      
-      Button {
-        Task {
-          isCropping = true
-          defer { isCropping = false }
-          await onComplete()
-        }
-      } label: {
-        Image(systemName: "checkmark")
-          .fontWeight(.semibold)
-          .foregroundStyle(configuration.colors.saveButton)
-      }
-      .padding()
-      .disabled(isCropping)
-#if !os(visionOS)
-      .glassEffect(.regular.tint(configuration.colors.saveButtonBackground))
-#endif
-    }
-    .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity)
 #else
-    VStack {
-      Text("iOS 26 is not supported. Adjust the simulator or your Xcode version.")
-    }
-    .border(.red)
+            VStack {
+                Text("iOS 26 is not supported. Adjust the simulator or your Xcode version.")
+            }
+            .border(.red)
 #endif
-  }
-}
+        }
+    }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -73,9 +73,9 @@ struct CropView: View {
             isCropping = false
           }
         }
+        .zIndex(1)
         .padding(.top, 60)
         .padding(.horizontal, 20)
-        .zIndex(1)
         
         Spacer()
         
@@ -101,6 +101,7 @@ struct CropView: View {
         
         if configuration.rotateImageWithButtons {
           Legacy_RotateButtonsView(viewModel: viewModel, configuration: configuration)
+            .zIndex(1)
         }
         
         Spacer()

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -73,14 +73,13 @@ struct CropView: View {
             isCropping = false
           }
         }
-        .zIndex(1)
         .padding(.top, 60)
         .padding(.horizontal, 20)
+        .zIndex(1)
         
         Spacer()
         
         cropImageView
-              .zIndex(0)
         
         Spacer()
       }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -80,6 +80,7 @@ struct CropView: View {
         Spacer()
         
         cropImageView
+              .zIndex(0)
         
         Spacer()
       }


### PR DESCRIPTION
### Summary
- Added `.interactive()` to the toolbar buttons' `glassEffect` to allow system app-like morphing.
- Wrapped the Liquid Glass toolbar in `GlassEffectContainer` to allow button interactions.
- (In consequence of adding GlassEffectContainer) Added `.contentShape` to `ToolbarView.swift` to capture hit-testing and fix the image blocking the toolbar button press.
- Added `.zIndex(1)` to the rotation buttons in the legacy view to put it in front of the image, same goal as above.

Before:

https://github.com/user-attachments/assets/c61abce5-3ea8-4652-b299-6229fef73764


After:

https://github.com/user-attachments/assets/97381165-86d9-4c85-891d-e2901ef834c6
