### PR TITLE
Add an optional zoom slider for pointer-based input

### DIFF
--- a/Demo/SwiftyCropDemo/ContentView.swift
+++ b/Demo/SwiftyCropDemo/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
   @State private var cropImageCircular: Bool
   @State private var rotateImage: Bool
   @State private var rotateImageWithButtons: Bool
+  @State private var showsZoomSlider: Bool
   @State private var maxMagnificationScale: CGFloat
   @State private var maskRadius: CGFloat
   @State private var zoomSensitivity: CGFloat
@@ -48,6 +49,7 @@ struct ContentView: View {
     _cropImageCircular = State(initialValue: defaultConfiguration.cropImageCircular)
     _rotateImage = State(initialValue: defaultConfiguration.rotateImage)
     _rotateImageWithButtons = State(initialValue: defaultConfiguration.rotateImageWithButtons)
+    _showsZoomSlider = State(initialValue: defaultConfiguration.showsZoomSlider)
     _maxMagnificationScale = State(initialValue: defaultConfiguration.maxMagnificationScale)
     _maskRadius = State(initialValue: defaultConfiguration.maskRadius)
     _zoomSensitivity = State(initialValue: defaultConfiguration.zoomSensitivity)
@@ -138,7 +140,9 @@ struct ContentView: View {
           Toggle("Rotate image (gestures)", isOn: $rotateImage)
           
           Toggle("Rotate image (buttons)", isOn: $rotateImageWithButtons)
-          
+
+          Toggle("Show zoom slider", isOn: $showsZoomSlider)
+
           HStack {
             Text("Max magnification")
               .frame(maxWidth: .infinity, alignment: .leading)
@@ -253,6 +257,7 @@ struct ContentView: View {
       cropImageCircular: cropImageCircular,
       rotateImage: rotateImage,
       rotateImageWithButtons: rotateImageWithButtons,
+      showsZoomSlider: showsZoomSlider,
       zoomSensitivity: zoomSensitivity,
       rectAspectRatio: rectAspectRatio.getValue(),
       allowAspectRatioResizing: allowAspectRatioResizing,

--- a/Demo/SwiftyCropDemo/ContentView.swift
+++ b/Demo/SwiftyCropDemo/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
   @State private var allowAspectRatioResizing: Bool
   @State private var minAspectRatio: CGFloat
   @State private var maxAspectRatio: CGFloat
+  @State private var dismissesOnCompletion: Bool
   @FocusState private var textFieldFocused: Bool
   @EnvironmentObject private var cropSession: CropSession
   #if os(macOS)
@@ -56,6 +57,7 @@ struct ContentView: View {
     _allowAspectRatioResizing = State(initialValue: defaultConfiguration.allowAspectRatioResizing)
     _minAspectRatio = State(initialValue: defaultConfiguration.minAspectRatio)
     _maxAspectRatio = State(initialValue: defaultConfiguration.maxAspectRatio)
+    _dismissesOnCompletion = State(initialValue: defaultConfiguration.dismissesOnCompletion)
   }
   
   var body: some View {
@@ -142,6 +144,8 @@ struct ContentView: View {
           Toggle("Rotate image (buttons)", isOn: $rotateImageWithButtons)
 
           Toggle("Show zoom slider", isOn: $showsZoomSlider)
+
+          Toggle("Dismiss on completion", isOn: $dismissesOnCompletion)
 
           HStack {
             Text("Max magnification")
@@ -242,10 +246,17 @@ struct ContentView: View {
         configuration: makeCropConfiguration(),
         onCancel: {
           print("Operation cancelled")
+          // With `dismissesOnCompletion` disabled, the presenting view dismisses the cropper itself
+          if !dismissesOnCompletion {
+            showImageCropper = false
+          }
         }
       ) { croppedImage in
         // Do something with the returned, cropped image
         self.selectedImage = croppedImage
+        if !dismissesOnCompletion {
+          showImageCropper = false
+        }
       }
     }
   }
@@ -263,6 +274,7 @@ struct ContentView: View {
       allowAspectRatioResizing: allowAspectRatioResizing,
       minAspectRatio: minAspectRatio,
       maxAspectRatio: maxAspectRatio,
+      dismissesOnCompletion: dismissesOnCompletion,
       colors: SwiftyCropConfiguration.Colors(
         cancelButton: Color.primary,
         interactionInstructions: Color.primary,

--- a/Demo/SwiftyCropDemo/SwiftyCropDemoApp.swift
+++ b/Demo/SwiftyCropDemo/SwiftyCropDemoApp.swift
@@ -37,6 +37,7 @@ struct SwiftyCropDemoApp: App {
 #if os(macOS)
 struct CropWindowView: View {
   @EnvironmentObject private var session: CropSession
+  @Environment(\.dismiss) private var dismiss
 
   var body: some View {
     if let image = session.image {
@@ -46,11 +47,19 @@ struct CropWindowView: View {
         configuration: session.configuration,
         onCancel: {
           session.onCancel?()
+          closeWindowIfNeeded()
         }
       ) { croppedImage in
         session.onComplete?(croppedImage)
+        closeWindowIfNeeded()
       }
     }
+  }
+
+  /// With `dismissesOnCompletion` disabled, the crop window is closed by the demo app instead of by SwiftyCrop.
+  private func closeWindowIfNeeded() {
+    guard !session.configuration.dismissesOnCompletion else { return }
+    dismiss()
   }
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ You can also configure `SwiftyCropView` by passing a `SwiftyCropConfiguration`. 
 | `allowAspectRatioResizing` | `Bool`: When using the `rectangle` mask shape, whether the user can freely resize the aspect ratio by dragging the edge handles. Defaults to `false`. |
 | `minAspectRatio` | `CGFloat`: The minimum allowed aspect ratio (width / height) when `allowAspectRatioResizing` is enabled. Defaults to `0.1`. |
 | `maxAspectRatio` | `CGFloat`: The maximum allowed aspect ratio (width / height) when `allowAspectRatioResizing` is enabled. Defaults to `10.0`. |
+| `dismissesOnCompletion` | `Bool`: Whether the cropping view dismisses itself after the save or cancel button was tapped. Set to `false` if the presenting view handles the dismissal itself. Defaults to `true`. |
 | `texts` | `Texts`: Defines custom texts for the buttons and instructions. Defaults to using localized strings from resources. |
 | `fonts` | `Fonts`: Defines custom fonts for the buttons and instructions. Defaults to using system font. |
 | `colors` | `Colors`: Defines custom colors for the texts and background. Defaults to white text and black background. |
@@ -271,6 +272,20 @@ Because the host app knows its own input devices best, this is a plain toggle ra
 
 > :bangbang: The slider occupies the same toolbar slot as the interaction instructions. While `showsZoomSlider` is enabled, the instructions text is not shown and `texts.interactionInstructions` has no effect.
 
+## 🚪 Dismissal
+
+By default the cropping view dismisses itself once the save or cancel button was tapped, right after `onComplete` / `onCancel` were called. If the presenting view needs to control the dismissal, set `dismissesOnCompletion` to `false` and perform the dismissal yourself.
+
+```swift
+let configuration = SwiftyCropConfiguration(
+    dismissesOnCompletion: false
+)
+```
+
+This is useful when the cropped image is processed before the UI moves on, for example when uploading it: the cropping view stays on screen until the upload succeeded, so a failed upload can show an error instead of losing the crop.
+
+> :bangbang: With `dismissesOnCompletion` set to `false`, SwiftyCrop never dismisses itself. The presenting view is responsible for dismissing it in `onComplete` and `onCancel`, otherwise the cropping view stays on screen.
+
 ## 🪟 iOS 26 & Liquid Glass
 
 To adopt the new Liquid Glass design Apple introduced with iOS 26, SwiftyCrop renders a UI that reflects this design (the screenshots above). This replaces text buttons with icon buttons and much more. It is applied automatically whenever iOS 26, visionOS 26 or macOS 26 is available; older OS versions fall back to the classic UI shown below. There is no toggle for it.
@@ -313,7 +328,7 @@ Thanks to [@andrewhanshaw](https://github.com/andrewhanshaw) for adding the aspe
 
 Another thanks to [@andrewhanshaw](https://github.com/andrewhanshaw) for overhauling the cropping UI with a native SwiftUI toolbar, native macOS window support and a unified Liquid Glass design 🛠️
 
-Thanks to [@ezathashim](https://github.com/ezathashim) for adding the zoom slider for input devices without pinch-to-zoom 🔍
+Thanks to [@ezathashim](https://github.com/ezathashim) for adding the zoom slider for input devices without pinch-to-zoom and for making the dismissal optional 🔍
 
 ## 📃 License
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The localization file can be found in `Sources/SwiftyCrop/Resources`.
 - [Demo App](#-demo-app)
 - [Usage](#-usage)
 - [Aspect Ratio Resizing](#-aspect-ratio-resizing)
+- [Zoom Slider](#-zoom-slider)
 - [iOS 26 & Liquid Glass](#-ios-26--liquid-glass)
 - [Contributors](#-contributors)
 - [License](#-license)
@@ -176,6 +177,7 @@ You can also configure `SwiftyCropView` by passing a `SwiftyCropConfiguration`. 
 | `cropImageCircular` | `Bool`: When using the cropping mask `circle`, whether the resulting image should also be masked as circle. Defaults to `false`. |
 | `rotateImage` | `Bool`: Whether the image can be rotated when cropping using pinch gestures. Defaults to `false`. |
 | `rotateImageWithButtons` | `Bool`: Option to show rotation buttons for rotating. Defaults to `false`. |
+| `showsZoomSlider` | `Bool`: Whether a zoom slider is shown for input devices that cannot pinch-to-zoom. Replaces the interaction instructions text while shown. Defaults to `false`. |
 | `zoomSensitivity` | `CGFloat`: Zoom sensitivity when cropping. Increase to make zoom faster / less sensitive. Defaults to `1.0`. |
 | `rectAspectRatio` | `CGFloat`: The aspect ratio to use when a rectangular mask shape is used. Defaults to `4:3`. |
 | `allowAspectRatioResizing` | `Bool`: When using the `rectangle` mask shape, whether the user can freely resize the aspect ratio by dragging the edge handles. Defaults to `false`. |
@@ -193,12 +195,14 @@ let configuration = SwiftyCropConfiguration(
     cropImageCircular: false,
     rotateImage: false,
     rotateImageWithButtons: false,
+    showsZoomSlider: false,
     zoomSensitivity: 1.0,
     rectAspectRatio: 4/3,
     texts: SwiftyCropConfiguration.Texts(
         cancelButton: "Cancel",
         interactionInstructions: "Custom instruction text",
-        saveButton: "Save"
+        saveButton: "Save",
+        zoomSliderLabel: "Zoom"
     ),
     fonts: SwiftyCropConfiguration.Fonts(
         cancelButton: Font.system(size: 12),
@@ -209,7 +213,8 @@ let configuration = SwiftyCropConfiguration(
         cancelButton: Color.red,
         interactionInstructions: Color.white,
         saveButton: Color.blue,
-        background: Color.gray
+        background: Color.gray,
+        zoomSlider: Color.white
     )
 )
 ```
@@ -245,6 +250,26 @@ let configuration = SwiftyCropConfiguration(
 <p align="center">
     <img src="Assets/aspect_crop.png" style="margin: auto; width: 250px"/>
 </p>
+
+## 🔍 Zoom Slider
+
+Zooming is normally done with a pinch gesture. That gesture is not available on every input device — a mouse on macOS or Catalyst cannot perform it, and neither can VoiceOver, Switch Control or Full Keyboard Access. Enable `showsZoomSlider` to additionally offer a slider, which drives the exact same scale as the pinch gesture.
+
+```swift
+let configuration = SwiftyCropConfiguration(
+    showsZoomSlider: true,
+    texts: SwiftyCropConfiguration.Texts(
+        zoomSliderLabel: "Zoom" // Accessibility label, defaults to the localized value
+    ),
+    colors: SwiftyCropConfiguration.Colors(
+        zoomSlider: Color.white
+    )
+)
+```
+
+Because the host app knows its own input devices best, this is a plain toggle rather than an automatic platform check — there is no reliable API to detect whether a trackpad is present.
+
+> :bangbang: The slider occupies the same toolbar slot as the interaction instructions. While `showsZoomSlider` is enabled, the instructions text is not shown and `texts.interactionInstructions` has no effect.
 
 ## 🪟 iOS 26 & Liquid Glass
 
@@ -287,6 +312,8 @@ Thanks to [@navanchauhan](https://github.com/navanchauhan) for adding native mac
 Thanks to [@andrewhanshaw](https://github.com/andrewhanshaw) for adding the aspect ratio resizing functionality 🎉
 
 Another thanks to [@andrewhanshaw](https://github.com/andrewhanshaw) for overhauling the cropping UI with a native SwiftUI toolbar, native macOS window support and a unified Liquid Glass design 🛠️
+
+Thanks to [@ezathashim](https://github.com/ezathashim) for adding the zoom slider for input devices without pinch-to-zoom 🔍
 
 ## 📃 License
 

--- a/Sources/SwiftyCrop/Models/CropViewModel.swift
+++ b/Sources/SwiftyCrop/Models/CropViewModel.swift
@@ -19,7 +19,7 @@ class CropViewModel: ObservableObject {
     private let minAspectRatio: CGFloat // The minimum allowed aspect ratio when resizing a rectangle mask.
     private let maxAspectRatio: CGFloat // The maximum allowed aspect ratio when resizing a rectangle mask.
     
-    var imageSizeInView: CGSize = .zero // The size of the image as displayed in the view.
+    @Published var imageSizeInView: CGSize = .zero // The size of the image as displayed in the view.
     @Published var maskSize: CGSize = .zero // The size of the mask used for cropping. This is updated based on the mask shape and available space.
     @Published var scale: CGFloat = 1.0 // The current scale factor of the image.
     @Published var lastScale: CGFloat = 1.0 // The previous scale factor of the image.
@@ -89,6 +89,7 @@ class CropViewModel: ObservableObject {
         let clamped = min(max(desired, minH), maxH)
         maskSize = CGSize(width: maskSize.width, height: clamped)
         rectAspectRatio = maskSize.width / clamped
+        clampScaleToMask()
     }
 
     /**
@@ -102,6 +103,20 @@ class CropViewModel: ObservableObject {
         let clamped = min(max(desired, minW), maxW)
         maskSize = CGSize(width: clamped, height: maskSize.height)
         rectAspectRatio = clamped / maskSize.height
+        clampScaleToMask()
+    }
+
+    /**
+     Clamps the current scale into the range that is valid for the current mask size.
+     Growing the mask raises the minimum scale, so the image has to catch up to keep filling the mask.
+     */
+    private func clampScaleToMask() {
+        guard imageSizeInView.width > 0, imageSizeInView.height > 0 else { return }
+        let maxScaleValues = calculateMagnificationGestureMaxValues()
+        let clamped = min(max(scale, maxScaleValues.0), maxScaleValues.1)
+        guard clamped != scale else { return }
+        scale = clamped
+        lastScale = clamped
     }
     
     /**

--- a/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
+++ b/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
@@ -23,7 +23,7 @@ public struct SwiftyCropConfiguration {
   ///
   /// - Parameters:
   ///   - cancelButton: The text for the cancel button. Defaults to `nil`, using localized values from the app.
-  ///   - interactionInstructions: The text for the interaction instructions. Defaults to `nil`, using localized values from the app.
+  ///   - interactionInstructions: The text for the interaction instructions. Defaults to `nil`, using localized values from the app. Has no effect while `showsZoomSlider` is enabled, as the slider replaces this text.
   ///   - saveButton: The text for the save button. Defaults to `nil`, using localized values from the app.
   ///   - progressLayerText: The text for the progress view indicating that cropping occurs. Defaults to `nil`, using localized values from the app.
   ///   - zoomSliderLabel: The accessibility label for the zoom slider. Unlike the button texts this applies on 26+ as well, since it is never displayed on screen. Defaults to `nil`, using localized values from the app.
@@ -88,6 +88,7 @@ public struct SwiftyCropConfiguration {
   ///   - saveButtonBackground: If Liquid Glass is enabled, will be the background color of the button. Otherwise has no effect. Defaults to `.yellow`.
   ///   - background: The background color of the entire cropping view. Defaults to `.black`.
   ///   - cropHandle: The color of the aspect ratio resize handles shown on rectangle masks (if allowAspectRatioResizing is enabled). Defaults to `.white`.
+  ///   - zoomSlider: The color of the zoom slider and its icons (if showsZoomSlider is enabled). Defaults to `.white`.
   public struct Colors {
     public init(
       cancelButton: Color = .white,
@@ -100,7 +101,8 @@ public struct SwiftyCropConfiguration {
       saveButton: Color = .white,
       saveButtonBackground: Color = .yellow,
       background: Color = .black,
-      cropHandle: Color = .white
+      cropHandle: Color = .white,
+      zoomSlider: Color = .white
     ) {
       self.cancelButton = cancelButton
       self.cancelButtonBackground = cancelButtonBackground
@@ -113,6 +115,7 @@ public struct SwiftyCropConfiguration {
       self.saveButtonBackground = saveButtonBackground
       self.background = background
       self.cropHandle = cropHandle
+      self.zoomSlider = zoomSlider
     }
     
     public let cancelButton: Color
@@ -126,6 +129,7 @@ public struct SwiftyCropConfiguration {
     public let saveButtonBackground: Color
     public let background: Color
     public let cropHandle: Color
+    public let zoomSlider: Color
   }
   
   /// Creates a new instance of `SwiftyCropConfiguration`.
@@ -141,7 +145,10 @@ public struct SwiftyCropConfiguration {
   ///
   ///   - rotateImageWithButtons: Option to show rotation buttons. Defaults to `false`.
   ///
-  ///   - showsZoomSlider: Option to show a zoom slider below the image, useful for input devices without pinch-to-zoom. Defaults to `false`.
+  ///   - showsZoomSlider: Option to show a zoom slider, useful for input devices that cannot pinch-to-zoom
+  ///   (mouse, VoiceOver, Switch Control, Full Keyboard Access). Defaults to `false`.
+  ///   - Important: The slider occupies the same toolbar slot as the interaction instructions. While it is shown,
+  ///   the instructions text is not displayed and `texts.interactionInstructions` has no effect.
   ///
   ///   - zoomSensitivity: Sensitivity when zooming. Default is `1.0`. Decrease to increase sensitivity.
   ///

--- a/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
+++ b/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
@@ -14,7 +14,7 @@ public struct SwiftyCropConfiguration {
   public let allowAspectRatioResizing: Bool
   public let minAspectRatio: CGFloat
   public let maxAspectRatio: CGFloat
-  public let dismissOnSaveCancelAction: Bool
+  public let dismissesOnCompletion: Bool
   public let texts: Texts
   public let fonts: Fonts
   public let colors: Colors
@@ -161,7 +161,8 @@ public struct SwiftyCropConfiguration {
   ///
   ///   - maxAspectRatio: The maximum allowed aspect ratio (width/height) when resizing a rectangle mask. Defaults to `10.0`.
   ///
-  ///   - dismissOnSaveCancelAction: will call dismiss() when pressing Save or Cancel. In some situsations, the dismissal is best handled by a super-view. Defaults to 'true'.
+  ///   - dismissesOnCompletion: Whether the cropping view dismisses itself after the save or cancel button was tapped.
+  ///   Set this to `false` if the presenting view handles the dismissal itself. Defaults to `true`.
   ///
   ///   - texts: `Texts` object when using custom texts for the cropping view.
   ///
@@ -180,7 +181,7 @@ public struct SwiftyCropConfiguration {
     allowAspectRatioResizing: Bool = false,
     minAspectRatio: CGFloat = 0.1,
     maxAspectRatio: CGFloat = 10.0,
-    dismissOnSaveCancelAction: Bool = true,
+    dismissesOnCompletion: Bool = true,
     texts: Texts = Texts(),
     fonts: Fonts = Fonts(),
     colors: Colors = Colors()
@@ -196,7 +197,7 @@ public struct SwiftyCropConfiguration {
     self.allowAspectRatioResizing = allowAspectRatioResizing
     self.minAspectRatio = minAspectRatio
     self.maxAspectRatio = maxAspectRatio
-    self.dismissOnSaveCancelAction = dismissOnSaveCancelAction
+    self.dismissesOnCompletion = dismissesOnCompletion
     self.texts = texts
     self.fonts = fonts
     self.colors = colors

--- a/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
+++ b/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
@@ -14,6 +14,7 @@ public struct SwiftyCropConfiguration {
   public let allowAspectRatioResizing: Bool
   public let minAspectRatio: CGFloat
   public let maxAspectRatio: CGFloat
+  public let dismissOnSaveCancelAction: Bool
   public let texts: Texts
   public let fonts: Fonts
   public let colors: Colors
@@ -160,6 +161,8 @@ public struct SwiftyCropConfiguration {
   ///
   ///   - maxAspectRatio: The maximum allowed aspect ratio (width/height) when resizing a rectangle mask. Defaults to `10.0`.
   ///
+  ///   - dismissOnSaveCancelAction: will call dismiss() when pressing Save or Cancel. In some situsations, the dismissal is best handled by a super-view. Defaults to 'true'.
+  ///
   ///   - texts: `Texts` object when using custom texts for the cropping view.
   ///
   ///   - fonts: `Fonts` object when using custom fonts for the cropping view. Defaults to system.
@@ -177,6 +180,7 @@ public struct SwiftyCropConfiguration {
     allowAspectRatioResizing: Bool = false,
     minAspectRatio: CGFloat = 0.1,
     maxAspectRatio: CGFloat = 10.0,
+    dismissOnSaveCancelAction: Bool = true,
     texts: Texts = Texts(),
     fonts: Fonts = Fonts(),
     colors: Colors = Colors()
@@ -192,6 +196,7 @@ public struct SwiftyCropConfiguration {
     self.allowAspectRatioResizing = allowAspectRatioResizing
     self.minAspectRatio = minAspectRatio
     self.maxAspectRatio = maxAspectRatio
+    self.dismissOnSaveCancelAction = dismissOnSaveCancelAction
     self.texts = texts
     self.fonts = fonts
     self.colors = colors

--- a/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
+++ b/Sources/SwiftyCrop/Models/SwiftyCropConfiguration.swift
@@ -8,6 +8,7 @@ public struct SwiftyCropConfiguration {
   public let cropImageCircular: Bool
   public let rotateImage: Bool
   public let rotateImageWithButtons: Bool
+  public let showsZoomSlider: Bool
   public let zoomSensitivity: CGFloat
   public let rectAspectRatio: CGFloat
   public let allowAspectRatioResizing: Bool
@@ -25,24 +26,28 @@ public struct SwiftyCropConfiguration {
   ///   - interactionInstructions: The text for the interaction instructions. Defaults to `nil`, using localized values from the app.
   ///   - saveButton: The text for the save button. Defaults to `nil`, using localized values from the app.
   ///   - progressLayerText: The text for the progress view indicating that cropping occurs. Defaults to `nil`, using localized values from the app.
+  ///   - zoomSliderLabel: The accessibility label for the zoom slider. Unlike the button texts this applies on 26+ as well, since it is never displayed on screen. Defaults to `nil`, using localized values from the app.
   public struct Texts {
     public init(
       // We cannot use the localized values here because module access is not given in init
       cancelButton: String? = nil,
       interactionInstructions: String? = nil,
       saveButton: String? = nil,
-      progressLayerText: String? = nil
+      progressLayerText: String? = nil,
+      zoomSliderLabel: String? = nil
     ) {
       self.cancelButton = cancelButton
       self.interactionInstructions = interactionInstructions
       self.saveButton = saveButton
       self.progressLayerText = progressLayerText
+      self.zoomSliderLabel = zoomSliderLabel
     }
     
     public let cancelButton: String?
     public let interactionInstructions: String?
     public let saveButton: String?
     public let progressLayerText: String?
+    public let zoomSliderLabel: String?
   }
   
   /// Creates a new instance of `Fonts` that are used in the cropping view texts.
@@ -136,6 +141,8 @@ public struct SwiftyCropConfiguration {
   ///
   ///   - rotateImageWithButtons: Option to show rotation buttons. Defaults to `false`.
   ///
+  ///   - showsZoomSlider: Option to show a zoom slider below the image, useful for input devices without pinch-to-zoom. Defaults to `false`.
+  ///
   ///   - zoomSensitivity: Sensitivity when zooming. Default is `1.0`. Decrease to increase sensitivity.
   ///
   ///   - rectAspectRatio: The aspect ratio to use when a `.rectangle` mask shape is used. Defaults to `4:3`.
@@ -157,6 +164,7 @@ public struct SwiftyCropConfiguration {
     cropImageCircular: Bool = false,
     rotateImage: Bool = false,
     rotateImageWithButtons: Bool = false,
+    showsZoomSlider: Bool = false,
     zoomSensitivity: CGFloat = 1,
     rectAspectRatio: CGFloat = 4/3,
     allowAspectRatioResizing: Bool = false,
@@ -171,6 +179,7 @@ public struct SwiftyCropConfiguration {
     self.cropImageCircular = cropImageCircular
     self.rotateImage = rotateImage
     self.rotateImageWithButtons = rotateImageWithButtons
+    self.showsZoomSlider = showsZoomSlider
     self.zoomSensitivity = zoomSensitivity
     self.rectAspectRatio = rectAspectRatio
     self.allowAspectRatioResizing = allowAspectRatioResizing

--- a/Sources/SwiftyCrop/Resources/Localizable.xcstrings
+++ b/Sources/SwiftyCrop/Resources/Localizable.xcstrings
@@ -1,291 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "cancel_button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Peru"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mégsem"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annullamento"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İptal"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скасувати"
-          }
-        },
-        "zh" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
-          }
-        }
-      }
-    },
-    "interaction_instructions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bewegen und Skalieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move and Scale"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover y Escalar"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Siirrä ja Skaalaa"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Déplacer et Dimensionner"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mozgatás és Méretezés"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muoversi e Scalare"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動・拡大縮小"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "움직여 조절하세요."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover e Dimensionar"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перемещение и Масштабирование"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taşıyın ve Ölçeklendirin"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переміщення та Масштабування"
-          }
-        },
-        "zh" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移动·缩放"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移動並縮放圖片來裁切"
-          }
-        }
-      }
-    },
-    "processing_label" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verarbeitung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procesando"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prosessoidaan"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traitement"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feldolgozás"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elaborazione"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "処理中"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "처리 중"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processando"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обработка"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İşleniyor"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обробка"
-          }
-        },
-        "zh" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "处理中"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "處理中"
-          }
-        }
-      }
-    },
     "Reset Rotation" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -571,6 +286,291 @@
         }
       }
     },
+    "cancel_button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peru"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mégsem"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annullamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмена"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İptal"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скасувати"
+          }
+        },
+        "zh" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "interaction_instructions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewegen und Skalieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move and Scale"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mover y Escalar"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siirrä ja Skaalaa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déplacer et Dimensionner"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mozgatás és Méretezés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muoversi e Scalare"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動・拡大縮小"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "움직여 조절하세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mover e Dimensionar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемещение и Масштабирование"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taşıyın ve Ölçeklendirin"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переміщення та Масштабування"
+          }
+        },
+        "zh" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移动·缩放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動並縮放圖片來裁切"
+          }
+        }
+      }
+    },
+    "processing_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verarbeitung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procesando"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prosessoidaan"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traitement"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feldolgozás"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elaborazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "処理中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "처리 중"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processando"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обработка"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İşleniyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обробка"
+          }
+        },
+        "zh" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "处理中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "處理中"
+          }
+        }
+      }
+    },
     "save_button" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -662,6 +662,102 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
+          }
+        }
+      }
+    },
+    "zoom_slider_label" : {
+      "comment" : "label to indicate the functionality of s zoom slider",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoomaus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nagyítás"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ズーム"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확대\/축소"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштаб"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yakınlaştırma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштаб"
+          }
+        },
+        "zh" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缩放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮放"
           }
         }
       }

--- a/Sources/SwiftyCrop/Resources/Localizable.xcstrings
+++ b/Sources/SwiftyCrop/Resources/Localizable.xcstrings
@@ -667,7 +667,7 @@
       }
     },
     "zoom_slider_label" : {
-      "comment" : "label to indicate the functionality of s zoom slider",
+      "comment" : "Accessibility label for the zoom slider",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {

--- a/Sources/SwiftyCrop/SwiftyCrop.swift
+++ b/Sources/SwiftyCrop/SwiftyCrop.swift
@@ -19,18 +19,18 @@ import AppKit
 public struct SwiftyCropView: View {
     private let maskShape: MaskShape
     private let configuration: SwiftyCropConfiguration
-    private let onCancel: (() -> Void)?
+    private let onCancel: (@MainActor () -> Void)?
 
     #if canImport(UIKit)
     private let imageToCrop: UIImage
-    private let onComplete: (UIImage?) -> Void
+    private let onComplete: @MainActor (UIImage?) -> Void
 
     public init(
         imageToCrop: UIImage,
         maskShape: MaskShape,
         configuration: SwiftyCropConfiguration = SwiftyCropConfiguration(),
-        onCancel: (() -> Void)? = nil,
-        onComplete: @escaping (UIImage?) -> Void
+        onCancel: (@MainActor () -> Void)? = nil,
+        onComplete: @escaping @MainActor (UIImage?) -> Void
     ) {
         self.imageToCrop = imageToCrop
         self.maskShape = maskShape
@@ -40,14 +40,14 @@ public struct SwiftyCropView: View {
     }
     #elseif canImport(AppKit)
     private let imageToCrop: NSImage
-    private let onComplete: (NSImage?) -> Void
+    private let onComplete: @MainActor (NSImage?) -> Void
 
     public init(
         imageToCrop: NSImage,
         maskShape: MaskShape,
         configuration: SwiftyCropConfiguration = SwiftyCropConfiguration(),
-        onCancel: (() -> Void)? = nil,
-        onComplete: @escaping (NSImage?) -> Void
+        onCancel: (@MainActor () -> Void)? = nil,
+        onComplete: @escaping @MainActor (NSImage?) -> Void
     ) {
         self.imageToCrop = imageToCrop
         self.maskShape = maskShape

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -72,7 +72,6 @@ struct CropView: View {
                 ),
                 in: scaleRange
             )
-            .frame(width: 160)
             .accessibilityLabel(zoomSliderLabel)
             Image(systemName: "plus.magnifyingglass")
         }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -248,14 +248,19 @@ struct CropView: View {
         configuration: configuration
       )
     }
+      
     ToolbarItem(placement: .principal) {
-      Text(
-        configuration.texts.interactionInstructions ??
-          NSLocalizedString("interaction_instructions", tableName: localizableTableName, bundle: .module, comment: "")
-      )
-      .padding(.horizontal)
-      .font(configuration.fonts.interactionInstructions)
-      .foregroundStyle(configuration.colors.interactionInstructions)
+        if configuration.showsZoomSlider, let scaleRange {
+            zoomSlider(scaleRange: scaleRange)
+        } else {
+            Text(
+                configuration.texts.interactionInstructions ??
+                NSLocalizedString("interaction_instructions", tableName: localizableTableName, bundle: .module, comment: "")
+            )
+            .padding(.horizontal)
+            .font(configuration.fonts.interactionInstructions)
+            .foregroundStyle(configuration.colors.interactionInstructions)
+        }
     }
     #if !os(visionOS)
     if #available(iOS 26, macOS 26, *) {
@@ -286,12 +291,6 @@ struct CropView: View {
       .disabled(isCropping)
       .tintedGlassEffect()
     }
-      
-      ToolbarItem(placement: .principal) {
-          if configuration.showsZoomSlider, let scaleRange {
-              zoomSlider(scaleRange: scaleRange)
-          }
-      }
   }
 
   private var maskHandlesOverlay: some View {

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -47,11 +47,8 @@ struct CropView: View {
   // MARK: - Body
   var body: some View {
     ZStack {
-        VStack(spacing: 0) {
-            cropImageView
-            zoomSlider
-        }
-      
+        cropImageView
+        
       if isCropping {
         ProgressLayer(configuration: configuration, localizableTableName: localizableTableName)
       }
@@ -65,26 +62,22 @@ struct CropView: View {
   }
     
         // MARK: - Zoom Slider
-    @ViewBuilder
-    private var zoomSlider: some View {
-        if configuration.showsZoomSlider, let scaleRange {
-            HStack(spacing: 12) {
-                Image(systemName: "minus.magnifyingglass")
-                Slider(
-                    value: Binding(
-                        get: { min(max(viewModel.scale, scaleRange.lowerBound), scaleRange.upperBound) },
-                        set: { setScale($0) }
-                    ),
-                    in: scaleRange
-                )
-                .accessibilityLabel(zoomSliderLabel)
-                Image(systemName: "plus.magnifyingglass")
-            }
-            .foregroundStyle(configuration.colors.interactionInstructions)
-            .frame(maxWidth: 320)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
+    private func zoomSlider(scaleRange: ClosedRange<CGFloat>) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "minus.magnifyingglass")
+            Slider(
+                value: Binding(
+                    get: { min(max(viewModel.scale, scaleRange.lowerBound), scaleRange.upperBound) },
+                    set: { setScale($0) }
+                ),
+                in: scaleRange
+            )
+            .frame(width: 160)
+            .accessibilityLabel(zoomSliderLabel)
+            Image(systemName: "plus.magnifyingglass")
         }
+        .foregroundStyle(configuration.colors.interactionInstructions)
+        .controlSize(.small)
     }
     
         /// The valid scale range, or nil before layout has measured the image.
@@ -293,6 +286,12 @@ struct CropView: View {
       .disabled(isCropping)
       .tintedGlassEffect()
     }
+      
+      ToolbarItem(placement: .principal) {
+          if configuration.showsZoomSlider, let scaleRange {
+              zoomSlider(scaleRange: scaleRange)
+          }
+      }
   }
 
   private var maskHandlesOverlay: some View {

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -47,8 +47,8 @@ struct CropView: View {
   // MARK: - Body
   var body: some View {
     ZStack {
-        cropImageView
-        
+      cropImageView
+      
       if isCropping {
         ProgressLayer(configuration: configuration, localizableTableName: localizableTableName)
       }
@@ -60,46 +60,6 @@ struct CropView: View {
       toolbarView
     }
   }
-    
-        // MARK: - Zoom Slider
-    private func zoomSlider(scaleRange: ClosedRange<CGFloat>) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "minus.magnifyingglass")
-            Slider(
-                value: Binding(
-                    get: { min(max(viewModel.scale, scaleRange.lowerBound), scaleRange.upperBound) },
-                    set: { setScale($0) }
-                ),
-                in: scaleRange
-            )
-            .frame(minWidth: 120, idealWidth: 160, maxWidth: 240)
-            .accessibilityLabel(zoomSliderLabel)
-            Image(systemName: "plus.magnifyingglass")
-        }
-        .foregroundStyle(configuration.colors.interactionInstructions)
-        .controlSize(.small)
-    }
-    
-        /// The valid scale range, or nil before layout has measured the image.
-    private var scaleRange: ClosedRange<CGFloat>? {
-        guard viewModel.imageSizeInView.width > 0,
-              viewModel.imageSizeInView.height > 0 else { return nil }
-        let maxScaleValues = viewModel.calculateMagnificationGestureMaxValues()
-        guard maxScaleValues.0 < maxScaleValues.1 else { return nil }
-        return maxScaleValues.0...maxScaleValues.1
-    }
-    
-    private func setScale(_ newScale: CGFloat) {
-        let maxScaleValues = viewModel.calculateMagnificationGestureMaxValues()
-        viewModel.scale = min(max(newScale, maxScaleValues.0), maxScaleValues.1)
-        viewModel.lastScale = viewModel.scale
-        updateOffset()
-    }
-    
-    private var zoomSliderLabel: String {
-        configuration.texts.zoomSliderLabel ??
-        NSLocalizedString("zoom_slider_label", tableName: localizableTableName, bundle: .module, comment: "")
-    }
   
   // MARK: - Gestures
   private var magnificationGesture: some Gesture {
@@ -223,6 +183,52 @@ struct CropView: View {
     .simultaneousGesture(configuration.rotateImage ? rotationGesture : nil)
   }
 
+  /// Slider to zoom the image without a pinch gesture, for input devices that cannot perform one
+  /// (mouse, VoiceOver, Switch Control, Full Keyboard Access).
+  private func zoomSlider(scaleRange: ClosedRange<CGFloat>) -> some View {
+    HStack(spacing: 8) {
+      Image(systemName: "minus.magnifyingglass")
+        .accessibilityHidden(true)
+
+      Slider(
+        value: Binding(
+          get: { min(max(viewModel.scale, scaleRange.lowerBound), scaleRange.upperBound) },
+          set: { setScale($0) }
+        ),
+        in: scaleRange
+      )
+      .frame(minWidth: 120, idealWidth: 160, maxWidth: 240)
+      .accessibilityLabel(zoomSliderLabel)
+
+      Image(systemName: "plus.magnifyingglass")
+        .accessibilityHidden(true)
+    }
+    .padding(.horizontal, 8)
+    .foregroundStyle(configuration.colors.zoomSlider)
+    .controlSize(.small)
+  }
+
+  /// The valid scale range, or `nil` before layout has measured the image.
+  private var scaleRange: ClosedRange<CGFloat>? {
+    guard viewModel.imageSizeInView.width > 0,
+          viewModel.imageSizeInView.height > 0 else { return nil }
+    let maxScaleValues = viewModel.calculateMagnificationGestureMaxValues()
+    guard maxScaleValues.0 < maxScaleValues.1 else { return nil }
+    return maxScaleValues.0...maxScaleValues.1
+  }
+
+  private func setScale(_ newScale: CGFloat) {
+    let maxScaleValues = viewModel.calculateMagnificationGestureMaxValues()
+    viewModel.scale = min(max(newScale, maxScaleValues.0), maxScaleValues.1)
+    viewModel.lastScale = viewModel.scale
+    updateOffset()
+  }
+
+  private var zoomSliderLabel: String {
+    configuration.texts.zoomSliderLabel ??
+      NSLocalizedString("zoom_slider_label", tableName: localizableTableName, bundle: .module, comment: "")
+  }
+
   @ToolbarContentBuilder
   private var toolbarView: some ToolbarContent {
     ToolbarItem(placement: .cancellationAction) {
@@ -248,19 +254,19 @@ struct CropView: View {
         configuration: configuration
       )
     }
-      
     ToolbarItem(placement: .principal) {
-        if configuration.showsZoomSlider, let scaleRange {
-            zoomSlider(scaleRange: scaleRange)
-        } else {
-            Text(
-                configuration.texts.interactionInstructions ??
-                NSLocalizedString("interaction_instructions", tableName: localizableTableName, bundle: .module, comment: "")
-            )
-            .padding(.horizontal)
-            .font(configuration.fonts.interactionInstructions)
-            .foregroundStyle(configuration.colors.interactionInstructions)
-        }
+      // The zoom slider takes over this slot, so the interaction instructions are hidden while it is shown.
+      if configuration.showsZoomSlider, let scaleRange {
+        zoomSlider(scaleRange: scaleRange)
+      } else {
+        Text(
+          configuration.texts.interactionInstructions ??
+            NSLocalizedString("interaction_instructions", tableName: localizableTableName, bundle: .module, comment: "")
+        )
+        .padding(.horizontal)
+        .font(configuration.fonts.interactionInstructions)
+        .foregroundStyle(configuration.colors.interactionInstructions)
+      }
     }
     #if !os(visionOS)
     if #available(iOS 26, macOS 26, *) {

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -15,16 +15,16 @@ struct CropView: View {
   private let image: PlatformImage
   private let maskShape: MaskShape
   private let configuration: SwiftyCropConfiguration
-  private let onCancel: (() -> Void)?
-  private let onComplete: (PlatformImage?) -> Void
+  private let onCancel: (@MainActor () -> Void)?
+  private let onComplete: @MainActor (PlatformImage?) -> Void
   private let localizableTableName: String
 
   init(
     image: PlatformImage,
     maskShape: MaskShape,
     configuration: SwiftyCropConfiguration,
-    onCancel: (() -> Void)? = nil,
-    onComplete: @escaping (PlatformImage?) -> Void
+    onCancel: (@MainActor () -> Void)? = nil,
+    onComplete: @escaping @MainActor (PlatformImage?) -> Void
   ) {
     self.image = image
     self.maskShape = maskShape

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -234,7 +234,9 @@ struct CropView: View {
     ToolbarItem(placement: .cancellationAction) {
       Button {
         onCancel?()
-        dismiss()
+        if configuration.dismissOnSaveCancelAction {
+            dismiss()
+        }
       } label: {
         Label(
           configuration.texts.cancelButton ??
@@ -279,9 +281,11 @@ struct CropView: View {
           await MainActor.run { isCropping = true }
           let result = cropImage()
           await MainActor.run {
-            onComplete(result)
-            dismiss()
             isCropping = false
+            onComplete(result)
+            if configuration.dismissOnSaveCancelAction {
+                dismiss()
+            }
           }
         }
       } label: {

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -72,6 +72,7 @@ struct CropView: View {
                 ),
                 in: scaleRange
             )
+            .frame(minWidth: 120, idealWidth: 160, maxWidth: 240)
             .accessibilityLabel(zoomSliderLabel)
             Image(systemName: "plus.magnifyingglass")
         }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -47,7 +47,10 @@ struct CropView: View {
   // MARK: - Body
   var body: some View {
     ZStack {
-      cropImageView
+        VStack(spacing: 0) {
+            cropImageView
+            zoomSlider
+        }
       
       if isCropping {
         ProgressLayer(configuration: configuration, localizableTableName: localizableTableName)
@@ -60,6 +63,50 @@ struct CropView: View {
       toolbarView
     }
   }
+    
+        // MARK: - Zoom Slider
+    @ViewBuilder
+    private var zoomSlider: some View {
+        if configuration.showsZoomSlider, let scaleRange {
+            HStack(spacing: 12) {
+                Image(systemName: "minus.magnifyingglass")
+                Slider(
+                    value: Binding(
+                        get: { min(max(viewModel.scale, scaleRange.lowerBound), scaleRange.upperBound) },
+                        set: { setScale($0) }
+                    ),
+                    in: scaleRange
+                )
+                .accessibilityLabel(zoomSliderLabel)
+                Image(systemName: "plus.magnifyingglass")
+            }
+            .foregroundStyle(configuration.colors.interactionInstructions)
+            .frame(maxWidth: 320)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+        }
+    }
+    
+        /// The valid scale range, or nil before layout has measured the image.
+    private var scaleRange: ClosedRange<CGFloat>? {
+        guard viewModel.imageSizeInView.width > 0,
+              viewModel.imageSizeInView.height > 0 else { return nil }
+        let maxScaleValues = viewModel.calculateMagnificationGestureMaxValues()
+        guard maxScaleValues.0 < maxScaleValues.1 else { return nil }
+        return maxScaleValues.0...maxScaleValues.1
+    }
+    
+    private func setScale(_ newScale: CGFloat) {
+        let maxScaleValues = viewModel.calculateMagnificationGestureMaxValues()
+        viewModel.scale = min(max(newScale, maxScaleValues.0), maxScaleValues.1)
+        viewModel.lastScale = viewModel.scale
+        updateOffset()
+    }
+    
+    private var zoomSliderLabel: String {
+        configuration.texts.zoomSliderLabel ??
+        NSLocalizedString("zoom_slider_label", tableName: localizableTableName, bundle: .module, comment: "")
+    }
   
   // MARK: - Gestures
   private var magnificationGesture: some Gesture {

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -234,8 +234,8 @@ struct CropView: View {
     ToolbarItem(placement: .cancellationAction) {
       Button {
         onCancel?()
-        if configuration.dismissOnSaveCancelAction {
-            dismiss()
+        if configuration.dismissesOnCompletion {
+          dismiss()
         }
       } label: {
         Label(
@@ -283,8 +283,8 @@ struct CropView: View {
           await MainActor.run {
             isCropping = false
             onComplete(result)
-            if configuration.dismissOnSaveCancelAction {
-                dismiss()
+            if configuration.dismissesOnCompletion {
+              dismiss()
             }
           }
         }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -428,7 +428,7 @@ struct RotationControlsView: ToolbarContent {
   @State private var showRotationPopover: Bool = false
 
   var body: some ToolbarContent {
-    #if os(iOS) || os(visionOS)
+    #if (os(iOS) && !targetEnvironment(macCatalyst)) || os(visionOS)
     ToolbarItem(placement: .navigation) {
       if #available(iOS 16.4, visionOS 1.0, *) {
         Button {

--- a/Tests/SwiftyCropTests/SwiftyCropTests.swift
+++ b/Tests/SwiftyCropTests/SwiftyCropTests.swift
@@ -10,12 +10,14 @@ final class SwiftyCropTests: XCTestCase {
       cropImageCircular: true,
       rotateImage: true,
       rotateImageWithButtons: true,
+      showsZoomSlider: true,
       zoomSensitivity: 2,
       rectAspectRatio: 4/3,
       texts: SwiftyCropConfiguration.Texts(
         cancelButton: "Test 1",
         interactionInstructions: "Test 2",
-        saveButton: "Test 3"
+        saveButton: "Test 3",
+        zoomSliderLabel: "Test 4"
       ),
       fonts: SwiftyCropConfiguration.Fonts(
         cancelButton: Font.system(size: 12),
@@ -26,7 +28,8 @@ final class SwiftyCropTests: XCTestCase {
         cancelButton: .red,
         interactionInstructions: .yellow,
         saveButton: .green,
-        background: .gray
+        background: .gray,
+        zoomSlider: .orange
       )
     )
     
@@ -35,13 +38,15 @@ final class SwiftyCropTests: XCTestCase {
     XCTAssertEqual(configuration.cropImageCircular, true)
     XCTAssertEqual(configuration.rotateImage, true)
     XCTAssertEqual(configuration.rotateImageWithButtons, true)
+    XCTAssertEqual(configuration.showsZoomSlider, true)
     XCTAssertEqual(configuration.zoomSensitivity, 2)
     XCTAssertEqual(configuration.rectAspectRatio, 4/3)
     
     XCTAssertEqual(configuration.texts.cancelButton, "Test 1")
     XCTAssertEqual(configuration.texts.interactionInstructions, "Test 2")
     XCTAssertEqual(configuration.texts.saveButton, "Test 3")
-    
+    XCTAssertEqual(configuration.texts.zoomSliderLabel, "Test 4")
+
     XCTAssertEqual(configuration.fonts.cancelButton, Font.system(size: 12))
     XCTAssertEqual(configuration.fonts.interactionInstructions, Font.system(size: 13))
     XCTAssertEqual(configuration.fonts.saveButton, Font.system(size: 14))
@@ -50,5 +55,14 @@ final class SwiftyCropTests: XCTestCase {
     XCTAssertEqual(configuration.colors.interactionInstructions, Color.yellow)
     XCTAssertEqual(configuration.colors.saveButton, Color.green)
     XCTAssertEqual(configuration.colors.background, Color.gray)
+    XCTAssertEqual(configuration.colors.zoomSlider, Color.orange)
+  }
+
+  func testZoomSliderDefaults() {
+    let configuration = SwiftyCropConfiguration()
+
+    XCTAssertEqual(configuration.showsZoomSlider, false)
+    XCTAssertNil(configuration.texts.zoomSliderLabel)
+    XCTAssertEqual(configuration.colors.zoomSlider, Color.white)
   }
 }

--- a/Tests/SwiftyCropTests/SwiftyCropTests.swift
+++ b/Tests/SwiftyCropTests/SwiftyCropTests.swift
@@ -13,6 +13,7 @@ final class SwiftyCropTests: XCTestCase {
       showsZoomSlider: true,
       zoomSensitivity: 2,
       rectAspectRatio: 4/3,
+      dismissesOnCompletion: false,
       texts: SwiftyCropConfiguration.Texts(
         cancelButton: "Test 1",
         interactionInstructions: "Test 2",
@@ -41,7 +42,8 @@ final class SwiftyCropTests: XCTestCase {
     XCTAssertEqual(configuration.showsZoomSlider, true)
     XCTAssertEqual(configuration.zoomSensitivity, 2)
     XCTAssertEqual(configuration.rectAspectRatio, 4/3)
-    
+    XCTAssertEqual(configuration.dismissesOnCompletion, false)
+
     XCTAssertEqual(configuration.texts.cancelButton, "Test 1")
     XCTAssertEqual(configuration.texts.interactionInstructions, "Test 2")
     XCTAssertEqual(configuration.texts.saveButton, "Test 3")
@@ -56,6 +58,12 @@ final class SwiftyCropTests: XCTestCase {
     XCTAssertEqual(configuration.colors.saveButton, Color.green)
     XCTAssertEqual(configuration.colors.background, Color.gray)
     XCTAssertEqual(configuration.colors.zoomSlider, Color.orange)
+  }
+
+  func testDismissesOnCompletionDefault() {
+    let configuration = SwiftyCropConfiguration()
+
+    XCTAssertEqual(configuration.dismissesOnCompletion, true)
   }
 
   func testZoomSliderDefaults() {


### PR DESCRIPTION
# Add an optional zoom slider for pointer-based input

Pinch-to-zoom is currently the only way to change the crop scale. That covers touch devices and Mac trackpads, but leaves out anyone on a mouse — every Mac Catalyst and macOS user without a trackpad, and iPad users with a pointing device — as well as anyone using VoiceOver, Switch Control, or Full Keyboard Access, since a magnification gesture isn't reachable through assistive input.

This adds `showsZoomSlider` to `SwiftyCropConfiguration` (defaults to `false`, so nothing changes for existing callers). When enabled, a compact slider takes the principal toolbar slot in place of the interaction-instructions text.

**Why the toolbar.** Putting the slider under `cropImageView` in a `VStack` shrinks the crop area, and since `maskRadius` is clamped to the image bounds, it shrinks the mask along with it. Overlaying it in a `ZStack` avoids that but collides with the mask on landscape images, where the image runs edge to edge vertically. The toolbar is fixed chrome, so the crop area keeps its full height and there's no overlap to manage.

**Why it replaces the instructions text.** "Pinch to zoom" is misleading advice on a device where the user can't pinch, which is exactly when the slider is shown. Happy to make this configurable instead if you'd rather keep both.

The slider and the gesture share one source of truth — `setScale(_:)` clamps through the same `calculateMagnificationGestureMaxValues()` call the gesture uses, so the two input paths can't disagree about limits.

## Usage

```swift
SwiftyCropView(
    imageToCrop: image,
    maskShape: .circle,
    configuration: SwiftyCropConfiguration(
        maskRadius: 300,
        showsZoomSlider: true,
        texts: SwiftyCropConfiguration.Texts(
            zoomSliderLabel: "Zoom"   // optional; falls back to the string catalog
        )
    )
) { croppedImage in
    // ...
}
```

The flag is a plain `Bool` rather than a platform check inside the package: there's no reliable API for trackpad presence, and platform is a poor proxy in both directions — a MacBook always has a trackpad, an iPad may not. The host app knows its own deployment context. In our case that's a single call like this:

```swift
showsZoomSlider: DeviceMonitor.shared.usesMacLayout
```