### PR TITLE
Crop in pixel space instead of point space

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         platform:
           - iOS
+          - macOS
+          - visionOS
         xcode:
           - ^26
 
@@ -31,21 +33,8 @@ jobs:
     - name: Print Swift version
       run: swift --version
     - name: Build & Test
-      uses: mxcl/xcodebuild@v1
+      # visionOS support was added in v3.1.0, so this has to stay on v3 or newer.
+      uses: mxcl/xcodebuild@v3
       with:
         xcode: ${{ matrix.xcode }}
         platform: ${{ matrix.platform }}
-
-  # mxcl/xcodebuild does not support visionOS, so build that target directly.
-  build-visionos:
-    runs-on: macos-15
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Select Xcode 26
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '^26'
-    - name: Build (visionOS)
-      run: xcodebuild -scheme SwiftyCrop -destination 'generic/platform=visionOS' build

--- a/Sources/SwiftyCrop/Models/CropViewModel.swift
+++ b/Sources/SwiftyCrop/Models/CropViewModel.swift
@@ -130,24 +130,9 @@ class CropViewModel: ObservableObject {
      */
     func cropToRectangle(_ image: PlatformImage) -> PlatformImage? {
         guard let orientedImage = image.correctlyOriented else { return nil }
-
-        let cropRect = calculateCropRect(orientedImage)
-
-        #if canImport(UIKit)
-        guard let cgImage = orientedImage.cgImage,
-              let result = cgImage.cropping(to: cropRect) else {
-            return nil
-        }
-        return UIImage(cgImage: result)
-        #elseif canImport(AppKit)
-        guard let cgImage = orientedImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
-              let croppedCGImage = cgImage.cropping(to: cropRect) else {
-            return nil
-        }
-        return NSImage(cgImage: croppedCGImage, size: cropRect.size)
-        #endif
+        return cropBitmap(of: orientedImage, to: calculateCropRect(orientedImage))
     }
-    
+
     /**
      Crops the given image to a square based on the current mask size and position.
      - Parameter image: The PlatformImage to crop.
@@ -155,24 +140,31 @@ class CropViewModel: ObservableObject {
      */
     func cropToSquare(_ image: PlatformImage) -> PlatformImage? {
         guard let orientedImage = image.correctlyOriented else { return nil }
+        return cropBitmap(of: orientedImage, to: calculateCropRect(orientedImage))
+    }
 
-        let cropRect = calculateCropRect(orientedImage)
-
+    /**
+     Crops the bitmap backing the given image to the given area.
+     - Parameter orientedImage: The correctly oriented PlatformImage to crop.
+     - Parameter cropRect: The area to keep, in the image's point coordinate space.
+     - Returns: A cropped PlatformImage, or nil if cropping fails.
+     */
+    private func cropBitmap(of orientedImage: PlatformImage, to cropRect: CGRect) -> PlatformImage? {
         #if canImport(UIKit)
         guard let cgImage = orientedImage.cgImage,
-              let result = cgImage.cropping(to: cropRect) else {
+              let result = cgImage.cropping(to: cropRect.inPixels(of: cgImage, pointSize: orientedImage.size)) else {
             return nil
         }
-        return UIImage(cgImage: result)
+        return UIImage(cgImage: result, scale: orientedImage.scale, orientation: .up)
         #elseif canImport(AppKit)
         guard let cgImage = orientedImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
-              let croppedCGImage = cgImage.cropping(to: cropRect) else {
+              let croppedCGImage = cgImage.cropping(to: cropRect.inPixels(of: cgImage, pointSize: orientedImage.size)) else {
             return nil
         }
         return NSImage(cgImage: croppedCGImage, size: cropRect.size)
         #endif
     }
-    
+
     /**
      Crops the given image to a circle based on the current mask size and position.
      - Parameter image: The PlatformImage to crop.
@@ -298,6 +290,32 @@ extension PlatformImage {
         #elseif canImport(AppKit)
         return self
         #endif
+    }
+}
+
+private extension CGRect {
+    /**
+     Converts a rect measured in an image's point coordinate space into the pixel coordinate space of
+     its bitmap, which is the space `CGImage.cropping(to:)` works in.
+
+     The two are not the same. On macOS `NSImage.size` is derived from the file's DPI metadata, so a
+     96 dpi image reports 0.75x its pixel dimensions. On iOS `UIImage.size` is the pixel size divided
+     by `scale`. Cropping a point sized rect out of the bitmap would keep too small an area, offset
+     towards the top left corner.
+     - Parameter cgImage: The bitmap the resulting rect is measured against.
+     - Parameter pointSize: The size of the image in points, as laid out on screen.
+     - Returns: The equivalent rect in pixels.
+     */
+    func inPixels(of cgImage: CGImage, pointSize: CGSize) -> CGRect {
+        guard pointSize.width > 0, pointSize.height > 0 else { return self }
+        let scaleX = CGFloat(cgImage.width) / pointSize.width
+        let scaleY = CGFloat(cgImage.height) / pointSize.height
+        return CGRect(
+            x: origin.x * scaleX,
+            y: origin.y * scaleY,
+            width: size.width * scaleX,
+            height: size.height * scaleY
+        )
     }
 }
 

--- a/Tests/SwiftyCropTests/CropGeometryTests.swift
+++ b/Tests/SwiftyCropTests/CropGeometryTests.swift
@@ -12,7 +12,7 @@ import UniformTypeIdentifiers
 /// both too small and offset towards the top left corner.
 final class CropGeometryTests: XCTestCase {
   func testSquareCropIsCentredWhenPointSizeDiffersFromPixelSize() throws {
-    // 800x600 pixels tagged as 144 dpi: `NSImage.size` reports 400x300, the bitmap stays 800x600.
+    // 800x600 pixels at 144 dpi: the image reports 400x300 points, the bitmap stays 800x600.
     let image = try XCTUnwrap(Self.makeSplitImage(pixelsWide: 800, pixelsHigh: 600, dpi: 144))
     let viewModel = Self.makeViewModel()
 
@@ -123,7 +123,14 @@ final class CropGeometryTests: XCTestCase {
     )
     guard CGImageDestinationFinalize(destination) else { return nil }
 
+    #if canImport(UIKit)
+    // `UIImage(data:)` ignores the DPI tag and always reports scale 1, which would make points and
+    // pixels identical and defeat the point of these tests. Pass the equivalent scale explicitly so
+    // both platforms end up with the same point size for the same bitmap.
+    return PlatformImage(data: data as Data, scale: dpi / 72)
+    #elseif canImport(AppKit)
     return PlatformImage(data: data as Data)
+    #endif
   }
 
   private static func cgImage(of image: PlatformImage) -> CGImage? {

--- a/Tests/SwiftyCropTests/CropGeometryTests.swift
+++ b/Tests/SwiftyCropTests/CropGeometryTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+import ImageIO
+import UniformTypeIdentifiers
+@testable import SwiftyCrop
+
+/// Regression tests for the mapping between an image's point coordinate space (`PlatformImage.size`)
+/// and the pixel coordinate space of its `CGImage`, which is what `CGImage.cropping(to:)` operates on.
+///
+/// The two are not the same. On macOS `NSImage.size` is derived from the file's DPI metadata, so a
+/// 96 dpi image reports 0.75x its pixel dimensions. On iOS `UIImage.size` is the pixel size divided
+/// by `scale`. Measuring the crop in points and then applying it to the bitmap yields a crop that is
+/// both too small and offset towards the top left corner.
+final class CropGeometryTests: XCTestCase {
+  func testSquareCropIsCentredWhenPointSizeDiffersFromPixelSize() throws {
+    // 800x600 pixels tagged as 144 dpi: `NSImage.size` reports 400x300, the bitmap stays 800x600.
+    let image = try XCTUnwrap(Self.makeSplitImage(pixelsWide: 800, pixelsHigh: 600, dpi: 144))
+    let viewModel = Self.makeViewModel()
+
+    // The crop view lays the image out and measures the result, so the view size is in points.
+    viewModel.updateMaskDimensions(for: image.size)
+
+    let cropped = try XCTUnwrap(viewModel.cropToSquare(image))
+    let bitmap = try XCTUnwrap(Self.cgImage(of: cropped))
+
+    // The source is black left of its centre and white right of it. Nothing was dragged or zoomed,
+    // so a correct crop is centred on the image and has to straddle that edge.
+    XCTAssertEqual(
+      Self.brightness(of: bitmap, atRelativeX: 0.25), 0, accuracy: 0.02,
+      "left half of the crop should fall in the black half of the source"
+    )
+    XCTAssertEqual(
+      Self.brightness(of: bitmap, atRelativeX: 0.75), 1, accuracy: 0.02,
+      "right half of the crop should fall in the white half of the source"
+    )
+  }
+
+  func testCropResolutionMatchesTheSelectedAreaInPixels() throws {
+    let image = try XCTUnwrap(Self.makeSplitImage(pixelsWide: 800, pixelsHigh: 600, dpi: 144))
+    let viewModel = Self.makeViewModel()
+    viewModel.updateMaskDimensions(for: image.size)
+
+    let cropped = try XCTUnwrap(viewModel.cropToSquare(image))
+    let bitmap = try XCTUnwrap(Self.cgImage(of: cropped))
+
+    // The mask covers `maskSize` of an image laid out at `image.size` points, and the bitmap behind
+    // those points is 800 pixels wide, so that fraction of 800 pixels has to survive the crop.
+    let pointsToPixels = 800 / image.size.width
+    let expected = viewModel.maskSize.width * pointsToPixels
+    XCTAssertEqual(CGFloat(bitmap.width), expected, accuracy: 1)
+    XCTAssertEqual(CGFloat(bitmap.height), expected, accuracy: 1)
+  }
+
+  func testDraggingTheImageMovesTheCropByTheSameAmount() throws {
+    let image = try XCTUnwrap(Self.makeSplitImage(pixelsWide: 800, pixelsHigh: 600, dpi: 144))
+    let viewModel = Self.makeViewModel()
+    viewModel.updateMaskDimensions(for: image.size)
+
+    // Drag the image 70 points to the left, which is the maximum the mask allows here.
+    XCTAssertEqual(viewModel.calculateDragGestureMax().x, 70, accuracy: 0.001)
+    viewModel.offset = CGSize(width: -70, height: 0)
+
+    let cropped = try XCTUnwrap(viewModel.cropToSquare(image))
+    let bitmap = try XCTUnwrap(Self.cgImage(of: cropped))
+
+    // In points the crop starts at 200 (centre) - 130 (half mask) + 70 (drag) = 140, so at pixel 280
+    // and 520 pixels wide. The black/white seam sits at pixel 400, i.e. 23% into the crop.
+    XCTAssertEqual(Self.seamRelativeX(of: bitmap), (400 - 280) / 520, accuracy: 0.01)
+  }
+
+  func testCircularCropIsCentredToo() throws {
+    let image = try XCTUnwrap(Self.makeSplitImage(pixelsWide: 800, pixelsHigh: 600, dpi: 144))
+    let viewModel = Self.makeViewModel()
+    viewModel.updateMaskDimensions(for: image.size)
+
+    let cropped = try XCTUnwrap(viewModel.cropToCircle(image))
+    let bitmap = try XCTUnwrap(Self.cgImage(of: cropped))
+
+    // The circle path renders in point space rather than cropping the bitmap, so it was never
+    // affected by the point/pixel mismatch. This pins that down.
+    XCTAssertEqual(Self.seamRelativeX(of: bitmap), 0.5, accuracy: 0.02)
+  }
+
+  // MARK: - Helpers
+
+  private static func makeViewModel() -> CropViewModel {
+    CropViewModel(
+      maskRadius: 130,
+      maxMagnificationScale: 4,
+      maskShape: .square,
+      rectAspectRatio: 1,
+      minAspectRatio: 0.1,
+      maxAspectRatio: 10
+    )
+  }
+
+  /// An image that is black in its left half and white in its right half, tagged with `dpi`.
+  private static func makeSplitImage(pixelsWide: Int, pixelsHigh: Int, dpi: CGFloat) -> PlatformImage? {
+    guard let context = CGContext(
+      data: nil,
+      width: pixelsWide,
+      height: pixelsHigh,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+    ) else { return nil }
+
+    context.setFillColor(gray: 0, alpha: 1)
+    context.fill(CGRect(x: 0, y: 0, width: pixelsWide / 2, height: pixelsHigh))
+    context.setFillColor(gray: 1, alpha: 1)
+    context.fill(CGRect(x: pixelsWide / 2, y: 0, width: pixelsWide - pixelsWide / 2, height: pixelsHigh))
+
+    guard let cgImage = context.makeImage() else { return nil }
+
+    let data = NSMutableData()
+    guard let destination = CGImageDestinationCreateWithData(
+      data, UTType.png.identifier as CFString, 1, nil
+    ) else { return nil }
+    CGImageDestinationAddImage(
+      destination,
+      cgImage,
+      [kCGImagePropertyDPIWidth: dpi, kCGImagePropertyDPIHeight: dpi] as CFDictionary
+    )
+    guard CGImageDestinationFinalize(destination) else { return nil }
+
+    return PlatformImage(data: data as Data)
+  }
+
+  private static func cgImage(of image: PlatformImage) -> CGImage? {
+    #if canImport(UIKit)
+    return image.cgImage
+    #elseif canImport(AppKit)
+    return image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+    #endif
+  }
+
+  /// The brightness of the pixel at `atRelativeX` (0...1) on the image's horizontal centre line.
+  private static func brightness(of cgImage: CGImage, atRelativeX relativeX: CGFloat) -> CGFloat {
+    let row = centreRow(of: cgImage)
+    let x = min(row.count - 1, max(0, Int(CGFloat(row.count) * relativeX)))
+    return row[x]
+  }
+
+  /// Where the source image's black/white seam ends up within the crop, as a fraction of its width.
+  private static func seamRelativeX(of cgImage: CGImage) -> CGFloat {
+    let row = centreRow(of: cgImage)
+    guard let seam = row.firstIndex(where: { $0 > 0.5 }) else { return .nan }
+    return CGFloat(seam) / CGFloat(row.count)
+  }
+
+  /// The brightness of every pixel on the image's horizontal centre line.
+  private static func centreRow(of cgImage: CGImage) -> [CGFloat] {
+    let width = cgImage.width
+    let height = cgImage.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+
+    pixels.withUnsafeMutableBytes { buffer in
+      let context = CGContext(
+        data: buffer.baseAddress,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+      context?.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+    }
+
+    let y = height / 2
+    return (0..<width).map { CGFloat(pixels[(y * width + $0) * 4]) / 255 }
+  }
+}


### PR DESCRIPTION
`calculateCropRect` measured against `PlatformImage.size` while `CGImage.cropping(to:)` cuts in pixels. The two differ whenever an image carries DPI metadata other than 72 on macOS, or a `scale` other than 1 on iOS, so the result came out too small and offset towards the top left.

The circular crop renders in point space and was never affected.